### PR TITLE
Fix to the "rat check" feature --

### DIFF
--- a/teampy/command_line_rat.py
+++ b/teampy/command_line_rat.py
@@ -102,7 +102,7 @@ def rat_check(file_input, file_path):
             print(Fore.RED + 'Question {} has no true answer. The first answer alternative must be the true one.'.format(question.number) + Style.RESET_ALL)
             return
     tell('The rat looks okay.')
-    latex = questionaire.write_latex(test_solution='bcdabdabdc')
+    latex = questionaire.write_latex()
     write_latex(latex, file_path)
 
 def parallel_file_path(file_path, alternative_extension):


### PR DESCRIPTION
When running a simple check:

```
rat check questions.txt

 _                                   
| |_ ___  __ _ _ __ ___  _ __  _   _ 
| __/ _ \/ _` | '_ ` _ \| '_ \| | | |
| ||  __/ (_| | | | | | | |_) | |_| |
 \__\___|\__,_|_| |_| |_| .__/ \__, |
                        |_|    |___/ 

 - The RAT has 6 questions.
 - The rat looks okay.
Traceback (most recent call last):
  File "/home/palma/.local/lib/python3.7/site-packages/teampy/command_line_rat.py", line 396, in <module>
    rat()
  File "/usr/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/palma/.local/lib/python3.7/site-packages/teampy/command_line_rat.py", line 347, in check
    rat_check(click.open_file(file, encoding='latin-1'), file)
  File "/home/palma/.local/lib/python3.7/site-packages/teampy/command_line_rat.py", line 105, in rat_check
    latex = questionaire.write_latex(test_solution='bcdabdabdc')
TypeError: write_latex() got an unexpected keyword argument 'test_solution'
```